### PR TITLE
Update minimum Emacs version

### DIFF
--- a/web-mode-edit-element-elements.el
+++ b/web-mode-edit-element-elements.el
@@ -10,6 +10,7 @@
 
 (require 'web-mode)
 (require 'web-mode-edit-element-utils)
+(require 'subr-x)
 
 ;; General
 (defun web-mode-edit-element-elements-end-inside ()

--- a/web-mode-edit-element.el
+++ b/web-mode-edit-element.el
@@ -8,7 +8,7 @@
 ;; License: GNU General Public License >= 2
 ;; Distribution: This file is not part of Emacs
 ;; Keywords: languages convenience
-;; Package-Requires: ((web-mode "14"))
+;; Package-Requires: ((emacs "24.4") (web-mode "14"))
 
 ;;; Commentary:
 


### PR DESCRIPTION
- string-trim-left was introduced at Emacs 24.4
- Load subr-x.el for using it